### PR TITLE
Add setup script for Overseer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-Overseer initial.
+# Overseer Action
+
+This repository contains the compiled GitHub Action used by Overseer.
+
+## VM Setup for Local Overseer Action
+
+The `setup_overseer_vm.sh` script prepares a fresh VM with everything required to run the Overseer Action completely offline after installation. It installs Node.js, the Model Context Protocol (MCP) servers, configures them to start on boot using **pm2**, and optionally installs Docker.
+
+### Usage
+
+Run the following on a new machine while it still has internet access:
+
+```bash
+sudo ./setup_overseer_vm.sh
+```
+
+Environment variables can adjust the behaviour:
+
+- `INSTALL_DOCKER` – set to `no` to skip Docker installation (default `yes`).
+- `DOCKER_IMAGES` – space-separated list of Docker images to pull.
+
+After the script completes, the MCP servers listen on ports 5000–5004. You can verify they are running by inspecting the pm2 process list or repeating the smoke tests:
+
+```bash
+pm2 ls
+curl http://localhost:5000
+```
+
+Once set up, the machine can operate without internet access and still provide the MCP services required by the Overseer Action.

--- a/setup_overseer_vm.sh
+++ b/setup_overseer_vm.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script installs everything needed to run the Overseer Action locally.
+# It should be executed on a fresh VM with internet access. After completion
+# the VM can be used offline.
+
+# Default ports for MCP servers
+MEMORY_PORT=5000
+SEQ_THINK_PORT=5001
+FILESYSTEM_PORT=5002
+GIT_PORT=5003
+TIME_PORT=5004
+
+# Update packages and install prerequisites
+sudo apt-get update -y
+sudo apt-get install -y curl git
+
+# Install Node.js LTS and npm from NodeSource
+curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Install pm2 and required MCP servers globally
+sudo npm install -g pm2 \
+  @modelcontextprotocol/server-memory \
+  @modelcontextprotocol/server-sequential-thinking \
+  @modelcontextprotocol/server-filesystem \
+  @modelcontextprotocol/server-git \
+  @modelcontextprotocol/server-time
+
+# Start MCP servers using pm2
+pm2 start $(which server-memory) --name mcp-memory -- --port "$MEMORY_PORT"
+pm2 start $(which server-sequential-thinking) --name mcp-sequential-thinking -- --port "$SEQ_THINK_PORT"
+pm2 start $(which server-filesystem) --name mcp-filesystem -- --port "$FILESYSTEM_PORT"
+pm2 start $(which server-git) --name mcp-git -- --port "$GIT_PORT"
+pm2 start $(which server-time) --name mcp-time -- --port "$TIME_PORT"
+
+# Configure pm2 to run on boot
+pm2 save
+pm2 startup systemd -u "${SUDO_USER:-$USER}" --hp "$HOME"
+
+# Optionally install Docker and pull images specified via DOCKER_IMAGES
+if [ "${INSTALL_DOCKER:-yes}" = "yes" ]; then
+  sudo apt-get install -y docker.io
+  sudo systemctl enable --now docker
+  if [ -n "${DOCKER_IMAGES:-}" ]; then
+    for img in $DOCKER_IMAGES; do
+      sudo docker pull "$img"
+    done
+  fi
+fi
+
+# Smoke test each MCP server
+for port in "$MEMORY_PORT" "$SEQ_THINK_PORT" "$FILESYSTEM_PORT" "$GIT_PORT" "$TIME_PORT"; do
+  echo "Testing MCP on port $port..."
+  if curl -fsS "http://localhost:$port" >/dev/null; then
+    echo "Port $port OK"
+  else
+    echo "Warning: no response on port $port" >&2
+  fi
+done
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add script to provision a VM with Node.js and all MCP servers
- document how to use this script in the README

## Testing
- `npm test` *(fails: Missing script)*