### PR TITLE
Add Jest tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/__tests__/memoryGraph.test.js
+++ b/__tests__/memoryGraph.test.js
@@ -1,0 +1,23 @@
+const axios = require('axios');
+jest.mock('axios');
+
+const { postMemoryGraph } = require('../dist/index');
+
+beforeEach(() => {
+  axios.post.mockReset();
+});
+
+describe('postMemoryGraph', () => {
+  test('posts when url provided', async () => {
+    axios.post.mockResolvedValue({});
+    await postMemoryGraph('http://localhost:1234/nodes', 1, 'summary');
+    expect(axios.post).toHaveBeenCalledWith('http://localhost:1234/nodes', {
+      entities: [{ name: 'PR-1', entityType: 'pull_request', observations: ['summary'] }]
+    });
+  });
+
+  test('skips when url missing', async () => {
+    await postMemoryGraph('', 1, 'summary');
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/run.integration.test.js
+++ b/__tests__/run.integration.test.js
@@ -1,0 +1,75 @@
+const express = require('express');
+jest.setTimeout(30000);
+
+jest.mock('@actions/core', () => ({
+  getInput: jest.fn((name) => {
+    if (name === 'github_token') return 'x';
+    if (name === 'todoist_api_key') return 'tok';
+  }),
+  info: jest.fn(),
+  warning: jest.fn(),
+  setFailed: jest.fn()
+}));
+
+jest.mock('@actions/github', () => {
+  const context = {
+    payload: {
+      pull_request: {
+        number: 1,
+        title: 'T',
+        body: 'B'
+      }
+    },
+    repo: { owner: 'me', repo: 'r' }
+  };
+  return {
+    context,
+    getOctokit: jest.fn(() => ({
+      rest: {
+        pulls: {
+          listFiles: jest.fn().mockResolvedValue({ data: [{ filename: 'f.js', status: 'added' }] })
+        },
+        issues: {
+          create: jest.fn().mockResolvedValue({ data: { number: 2 } })
+        }
+      }
+    }))
+  };
+});
+
+const { run } = require('../dist/index');
+
+let memoryBody;
+let todoistBody;
+let memoryServer;
+let todoistServer;
+
+beforeAll((done) => {
+  const app1 = express();
+  app1.use(express.json());
+  app1.post('/nodes', (req, res) => { memoryBody = req.body; res.sendStatus(200); });
+  memoryServer = app1.listen(0, () => {
+    const { port } = memoryServer.address();
+    process.env.MEMORY_MCP_URL = `http://localhost:${port}/nodes`;
+    const app2 = express();
+    app2.use(express.json());
+    app2.post('/tasks', (req, res) => { todoistBody = req.body; res.sendStatus(200); });
+    todoistServer = app2.listen(0, () => {
+      const { port: p2 } = todoistServer.address();
+      process.env.TODOIST_API_URL = `http://localhost:${p2}`;
+      done();
+    });
+  });
+});
+
+afterAll((done) => {
+  memoryServer.close(() => {
+    todoistServer.close(done);
+  });
+});
+
+test('run posts to servers', async () => {
+  await run();
+  expect(memoryBody).toBeTruthy();
+  expect(todoistBody).toBeTruthy();
+});

--- a/__tests__/summary.test.js
+++ b/__tests__/summary.test.js
@@ -1,0 +1,12 @@
+const { buildSummary } = require('../dist/index');
+
+describe('buildSummary', () => {
+  test('creates summary string', () => {
+    const pr = { number: 5, title: 'Test', body: 'Body' };
+    const changedFiles = '- a.txt (added)\n- b.js (modified)';
+    const summary = buildSummary(pr, changedFiles);
+    expect(summary).toContain('PR #5: Test');
+    expect(summary).toContain('Body');
+    expect(summary).toContain(changedFiles);
+  });
+});

--- a/__tests__/todoist.test.js
+++ b/__tests__/todoist.test.js
@@ -1,0 +1,25 @@
+const axios = require('axios');
+jest.mock('axios');
+
+const { postTodoist } = require('../dist/index');
+
+beforeEach(() => {
+  axios.post.mockReset();
+});
+
+describe('postTodoist', () => {
+  test('posts when key provided', async () => {
+    axios.post.mockResolvedValue({});
+    process.env.TODOIST_API_URL = 'http://localhost:5555';
+    await postTodoist('tok', 'repo', 'title');
+    expect(axios.post).toHaveBeenCalledWith('http://localhost:5555/tasks', {
+      content: 'Repo repo: title',
+      description: 'See GitHub issue for details'
+    }, { headers: { Authorization: 'Bearer tok' } });
+  });
+
+  test('skips when no key', async () => {
+    await postTodoist('', 'repo', 'title');
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,5 +8,20 @@
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "express": "^4.19.2",
+    "supertest": "^6.3.3"
+  },
+  "scripts": {
+    "test": "jest --coverage"
+  },
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "lines": 80
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add buildSummary, postMemoryGraph and postTodoist helpers
- export helpers from action entrypoint
- provide Jest unit tests and an integration test
- add GitHub Actions workflow to run npm test
- configure jest coverage threshold

## Testing
- `npm test` *(fails: jest not found)*