### PR TITLE
Add MCP task generation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,11 +1,45 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 const axios = require('axios');
+const fs = require('fs');
+const { spawn } = require('child_process');
+
+function buildPrompt(prSummary, roadmapTasks) {
+  const roadmapSection = roadmapTasks.length ? `\n\nOpen roadmap tasks:\n- ${roadmapTasks.join('\n- ')}` : '';
+  return `Using the PR summary below, suggest follow up tasks as a JSON array.\n\nPR Summary:\n${prSummary}${roadmapSection}`;
+}
+
+function parseTasks(respData) {
+  try {
+    if (typeof respData === 'string') {
+      return JSON.parse(respData).tasks || [];
+    }
+    return respData.tasks || [];
+  } catch (e) {
+    return [];
+  }
+}
+
+async function getRoadmapTasks() {
+  try {
+    const content = fs.readFileSync('ROADMAP.md', 'utf8');
+    return content.split('\n').filter(l => l.startsWith('- [ ]')).map(l => l.replace(/^- \[ \] /, '').trim());
+  } catch (e) {
+    return [];
+  }
+}
+
+async function callMcp(prompt, port) {
+  const url = `http://localhost:${port}/`;
+  const res = await axios.post(url, { prompt });
+  return parseTasks(res.data);
+}
 
 async function run() {
   try {
     const githubToken = core.getInput('github_token', { required: true });
     const todoistApiKey = core.getInput('todoist_api_key');
+    if (todoistApiKey) core.setSecret(todoistApiKey);
 
     const octokit = github.getOctokit(githubToken);
     const { context } = github;
@@ -30,34 +64,52 @@ async function run() {
     // Build summary
     const prSummary = `PR #${prNumber}: ${pr.title}\n\n${pr.body || ''}\n\nChanged files:\n${changedFiles}`;
 
-    // 2. (Placeholder) Post to Memory Graph MCP
+    // Start MCP server
+    const mcpPort = process.env.MCP_PORT || 7000;
+    core.info(`Starting MCP server on port ${mcpPort}`);
+    const mcpProc = spawn('npx', ['-y', '@modelcontextprotocol/server-sequential-thinking', '--port', mcpPort], { stdio: 'inherit' });
+    await new Promise(r => setTimeout(r, 2000));
+
+    const roadmapTasks = await getRoadmapTasks();
+    const prompt = buildPrompt(prSummary, roadmapTasks);
+
+    let tasks = [];
     try {
-      const memoryUrl = process.env.MEMORY_MCP_URL; // e.g., http://localhost:5000/nodes
-      if (memoryUrl) {
-        await axios.post(memoryUrl, {
-          entities: [{ name: `PR-${prNumber}`, entityType: 'pull_request', observations: [prSummary] }]
-        });
-        core.info('Posted summary to Memory Graph.');
-      } else {
-        core.info('MEMORY_MCP_URL not set – skipping Memory Graph step.');
-      }
+      tasks = await callMcp(prompt, mcpPort);
     } catch (err) {
-      core.warning(`Memory Graph post failed: ${err.message}`);
+      core.warning(`MCP call failed: ${err.message}`);
+    } finally {
+      mcpProc.kill();
     }
 
-    // 3. Create follow-up GitHub issue
-    const issueTitle = `Follow-up tasks after PR #${prNumber}`;
-    const issueBody = `Automatically generated tasks after merging PR #${prNumber}.\n\n### Summary\n${prSummary}\n\n### TODO\n- [ ] Assess refactors\n- [ ] Update documentation\n- [ ] Write tests\n`;
+    if (!tasks.length) {
+      core.info('No follow-up tasks received from MCP.');
+      return;
+    }
 
-    const issueResp = await octokit.rest.issues.create({ owner, repo, title: issueTitle, body: issueBody });
-    core.info(`Created issue #${issueResp.data.number}.`);
+    // Create GitHub issues for each task
+    for (const t of tasks) {
+      const title = t.title || t;
+      const body = t.body || `Task generated from PR #${prNumber}.`;
+
+      // search for existing umbrella issue
+      const { data: issues } = await octokit.rest.issues.listForRepo({ owner, repo, state: 'open', per_page: 100 });
+      let existing = issues.find(i => i.title === title);
+      if (existing) {
+        await octokit.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
+        core.info(`Appended comment to issue #${existing.number}`);
+      } else {
+        const resp = await octokit.rest.issues.create({ owner, repo, title, body });
+        core.info(`Created issue #${resp.data.number}.`);
+      }
+    }
 
     // 4. Send to Todoist if API key provided
     if (todoistApiKey) {
       try {
         await axios.post('https://api.todoist.com/rest/v2/tasks', {
-          content: `Repo ${repo}: ${issueTitle}`,
-          description: 'See GitHub issue for details',
+          content: `Repo ${repo}: Follow-up tasks from PR #${prNumber}`,
+          description: 'See GitHub issues for details',
         }, {
           headers: { Authorization: `Bearer ${todoistApiKey}` }
         });
@@ -71,4 +123,8 @@ async function run() {
   }
 }
 
-run();
+module.exports = { run, buildPrompt, parseTasks, callMcp };
+
+if (require.main === module) {
+  run();
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Repo Overseer GitHub Action",
   "main": "dist/index.js",
   "license": "MIT",
+  "scripts": {
+    "test": "node test/index.test.js"
+  },
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const http = require('http');
+const Module = require('module');
+process.env.NODE_PATH = __dirname + '/stubs';
+Module._initPaths();
+
+const { parseTasks, callMcp } = require('../dist/index');
+
+// parseTasks happy path
+assert.deepStrictEqual(parseTasks('{"tasks":[{"title":"a"}]}')[0].title, 'a');
+assert.deepStrictEqual(parseTasks({tasks:[{title:'b'}]})[0].title, 'b');
+assert.deepStrictEqual(parseTasks('bad json'), []);
+
+// callMcp happy path using stub server
+const tasks = [{title:'x'},{title:'y'}];
+const server = http.createServer((req,res)=>{
+  let body='';
+  req.on('data',d=>body+=d);
+  req.on('end',()=>{
+    res.writeHead(200, {'Content-Type':'application/json'});
+    res.end(JSON.stringify({tasks}));
+  });
+});
+server.listen(0, async () => {
+  const port = server.address().port;
+  const resp = await callMcp('hi', port);
+  assert.deepStrictEqual(resp, tasks);
+  server.close(runErrorTest);
+});
+
+function runErrorTest(){
+  const badServer = http.createServer((req,res)=>{
+    res.writeHead(500);
+    res.end('error');
+  });
+  badServer.listen(0, async ()=>{
+    const port = badServer.address().port;
+    try {
+      await callMcp('hi', port);
+      assert.fail('should throw');
+    } catch(e){
+      assert.ok(e);
+    }
+    badServer.close(()=>console.log('tests passed'));
+  });
+}

--- a/test/stubs/@actions/core/index.js
+++ b/test/stubs/@actions/core/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  getInput: () => '',
+  setSecret: () => {},
+  info: () => {},
+  warning: () => {},
+  setFailed: msg => { throw new Error(msg); }
+};

--- a/test/stubs/@actions/github/index.js
+++ b/test/stubs/@actions/github/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  getOctokit: () => ({
+    rest: {
+      pulls: { listFiles: async () => ({ data: [] }) },
+      issues: {
+        listForRepo: async () => ({ data: [] }),
+        create: async () => ({ data: { number: 1 } }),
+        createComment: async () => ({})
+      }
+    }
+  }),
+  context: { repo: { owner: 'o', repo: 'r' }, payload: { pull_request: { number: 1, title: '', body: '' } } }
+};

--- a/test/stubs/axios/index.js
+++ b/test/stubs/axios/index.js
@@ -1,0 +1,27 @@
+const http = require('http');
+const { URL } = require('url');
+module.exports = {
+  post: (url, data, opts={}) => new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = http.request({ hostname:u.hostname, port:u.port, path:u.pathname, method:'POST', headers:opts.headers || {'Content-Type':'application/json'} }, res => {
+      let body='';
+      res.on('data', c=>body+=c);
+      res.on('end', () => {
+        try { resolve({ data: JSON.parse(body) }); } catch { resolve({ data: body }); }
+      });
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(data));
+    req.end();
+  }),
+  get: (url) => new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = http.request({ hostname:u.hostname, port:u.port, path:u.pathname, method:'GET' }, res => {
+      let body='';
+      res.on('data', c => body+=c);
+      res.on('end', () => resolve({ data: body }));
+    });
+    req.on('error', reject);
+    req.end();
+  })
+};


### PR DESCRIPTION
## Summary
- start a local sequential-thinking MCP server
- gather PR info and roadmap tasks, build prompt, and request follow-up tasks
- create issues for MCP-suggested tasks
- mask secrets and expose MCP port by env var
- add minimal unit tests with local module stubs

## Testing
- `npm test`