### PR TITLE
Add MCP integration for follow-up tasks

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const nock = require('nock');
+const { parseRoadmap, buildPrompt, callMcp } = require('../dist/index');
+
+describe('roadmap parsing', () => {
+  test('reads open tasks', () => {
+    const file = path.join(__dirname, 'ROADMAP.md');
+    fs.writeFileSync(file, '- [ ] task one\n- [x] done\n- [ ] task two\n');
+    expect(parseRoadmap(file)).toEqual(['task one', 'task two']);
+    fs.unlinkSync(file);
+  });
+});
+
+describe('MCP call', () => {
+  test('parses tasks from response', async () => {
+    const scope = nock('http://localhost:7000').post('/').reply(200, {
+      tasks: [{ title: 'a', body: '' }]
+    });
+    const tasks = await callMcp('prompt', 7000);
+    expect(tasks).toEqual([{ title: 'a', body: '' }]);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  test('throws on invalid response', async () => {
+    nock('http://localhost:7000').post('/').reply(200, {});
+    await expect(callMcp('prompt', 7000)).rejects.toThrow('Invalid MCP response');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,9 +4,16 @@
   "description": "Repo Overseer GitHub Action",
   "main": "dist/index.js",
   "license": "MIT",
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "nock": "^13.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- integrate sequential-thinking MCP server
- generate prompt from PR summary and roadmap tasks
- create follow-up issues from MCP suggestions
- add unit tests for roadmap parsing and MCP call

## Testing
- `npm test --silent` *(fails: jest not found)*